### PR TITLE
Add /api/url-ready endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,8 @@ Endpoints:
       "status": "Running"
     }
   ]
-}```
+}
+```
 
 `GET /api/url-ready?url=https://asdfgh.cyverse.run` - Returns a JSON encoded object containing the result of checking whether the given URL returns a 200 series status code when hit with an HTTP client and whether the subdomain is configured as an Ingress in the Kubernetes cluster. The URL passed in must have a subdomain of the configured VICE domain. If the `url` query parameter is missing then a 400 will be returned.
 
@@ -31,4 +32,5 @@ The JSON returned in the response should look like the following:
 ```json
 {
   "ready" : true
-}```
+}
+```

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Endpoints:
 
 `GET /` - Returns a 404 page/loading page for a running VICE app.
 
-`GET /api/jobs/status-updates?url=https://asdfgh.cyverse.run` - Returns a JSON encoded listing of job status updates for the job associated with the URL that is passed in as a query parameter. If the `url` query parameter is missing then a 404 will be returned.
+`GET /api/jobs/status-updates?url=https://asdfgh.cyverse.run` - Returns a JSON encoded listing of job status updates for the job associated with the URL that is passed in as a query parameter. If the `url` query parameter is missing then a 400 will be returned.
 
  The JSON returned in the response should look like the following:
 
@@ -24,7 +24,7 @@ Endpoints:
   ]
 }```
 
-`GET /api/url-ready?url=https://asdfgh.cyverse.run` - Returns a JSON encoded object containing the result of checking whether the given URL returns a 200 series status code when hit with an HTTP client and whether the subdomain is configured as an Ingress in the Kubernetes cluster. The URL passed in must have a subdomain of the configured VICE domain. If the `url` query parameter is missing then a 404 will be returned.
+`GET /api/url-ready?url=https://asdfgh.cyverse.run` - Returns a JSON encoded object containing the result of checking whether the given URL returns a 200 series status code when hit with an HTTP client and whether the subdomain is configured as an Ingress in the Kubernetes cluster. The URL passed in must have a subdomain of the configured VICE domain. If the `url` query parameter is missing then a 400 will be returned.
 
 The JSON returned in the response should look like the following:
 

--- a/README.md
+++ b/README.md
@@ -23,3 +23,12 @@ Endpoints:
     }
   ]
 }```
+
+`GET /api/url-ready?url=https://asdfgh.cyverse.run` - Returns a JSON encoded object containing the result of checking whether the given URL returns a 200 series status code when hit with an HTTP client and whether the subdomain is configured as an Ingress in the Kubernetes cluster. The URL passed in must have a subdomain of the configured VICE domain. If the `url` query parameter is missing then a 404 will be returned.
+
+The JSON returned in the response should look like the following:
+
+```json
+{
+  "ready" : true
+}```

--- a/main.go
+++ b/main.go
@@ -556,7 +556,7 @@ func (c *CASProxy) URLIsReady(w http.ResponseWriter, r *http.Request) {
 
 	subdomain, err := extractSubdomain(u)
 	if err != nil {
-		http.Error(w, fmt.Sprintf("error getting subdomain for URL %s", u), http.StatusInternalServerError)
+		http.Error(w, fmt.Sprintf("error getting subdomain for URL %s", u), http.StatusBadRequest)
 		return
 	}
 	if subdomain == "" {

--- a/main.go
+++ b/main.go
@@ -38,19 +38,20 @@ const sessionKey = "proxy-session-key"
 // CASProxy contains the application logic that handles authentication, session
 // validations, ticket validation, and request proxying.
 type CASProxy struct {
-	casBase        string // base URL for the CAS server
-	casValidate    string // The path to the validation endpoint on the CAS server.
-	frontendURL    string // The URL placed into service query param for CAS.
-	resourceType   string // The resource type for analysis.
-	resourceName   string // The UUID of the analysis.
-	subjectType    string // The subject type for a user.
-	ingressURL     string // The URL to the cluster ingress.
-	accessHeader   string // The Host header for checking resource access perms.
-	analysisHeader string // The Host header for getting the analysis ID.
-	viceDomain     string // The domain for VICE apps.
-	sessionStore   *sessions.CookieStore
-	refreshEnabled bool   // Whether or not to look up information through the graphql server.
-	graphqlBase    string // The base URL to the graphql server.
+	casBase          string // base URL for the CAS server
+	casValidate      string // The path to the validation endpoint on the CAS server.
+	frontendURL      string // The URL placed into service query param for CAS.
+	resourceType     string // The resource type for analysis.
+	resourceName     string // The UUID of the analysis.
+	subjectType      string // The subject type for a user.
+	ingressURL       string // The URL to the cluster ingress.
+	appExposerHeader string // The Host header for hitting the app-exposer service.
+	accessHeader     string // The Host header for checking resource access perms.
+	analysisHeader   string // The Host header for getting the analysis ID.
+	viceDomain       string // The domain for VICE apps.
+	sessionStore     *sessions.CookieStore
+	refreshEnabled   bool   // Whether or not to look up information through the graphql server.
+	graphqlBase      string // The base URL to the graphql server.
 }
 
 // Analysis contains the ID for the Analysis, which gets used as the resource
@@ -319,11 +320,21 @@ func (c *CASProxy) NeedsSession(r *http.Request, m *mux.RouteMatch) bool {
 	return false
 }
 
+// URLMatches returns true if the given URL is a subdomain of the configured
+// VICE domain.
+func (c *CASProxy) URLMatches(url string) (bool, error) {
+	r := fmt.Sprintf("a.*\\.\\Q%s\\E(:[0-9]+)?", c.viceDomain)
+	matched, err := regexp.MatchString(r, url)
+	if err != nil {
+		return false, err
+	}
+	return matched, nil
+}
+
 // ViceSubdomain implements the mux.Matcher interface so that requests can be
 // routed based on whether they're a request to a VICE app UI or not.
 func (c *CASProxy) ViceSubdomain(r *http.Request, m *mux.RouteMatch) bool {
-	log.Println(r.Header.Get("X-Frontend-Url"))
-	matched, err := regexp.MatchString(fmt.Sprintf("a.*\\.\\Q%s\\E(:[0-9]+)?", c.viceDomain), r.Header.Get("X-Frontend-Url"))
+	matched, err := c.URLMatches(r.Header.Get("X-Frontend-Url"))
 	if err != nil {
 		log.Errorf("error checking for vice subdomain: %s", err)
 		return false
@@ -345,6 +356,35 @@ func extractSubdomain(jobURL string) (string, error) {
 		return fields[0], nil
 	}
 	return strings.Join(fields[:len(fields)-2], "."), nil
+}
+
+// IngressExists uses the app-exposer service to figure out if the provided
+// subdomain exists as an Ingress in the K8s cluster.
+func (c *CASProxy) IngressExists(subdomain string) (bool, error) {
+	ingressURL, err := url.Parse(c.ingressURL)
+	if err != nil {
+		return false, err
+	}
+	ingressURL.Path = filepath.Join(ingressURL.Path, fmt.Sprintf("/ingress/%s", subdomain))
+
+	request, err := http.NewRequest(http.MethodGet, ingressURL.String(), nil)
+	if err != nil {
+		return false, err
+	}
+
+	request.Host = c.appExposerHeader
+
+	client := &http.Client{}
+	resp, err := client.Do(request)
+	if err != nil {
+		return false, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode < 200 || resp.StatusCode > 299 {
+		return false, nil
+	}
+	return true, nil
 }
 
 const lookupExternalUUIDQuery = `
@@ -450,6 +490,61 @@ func (c *CASProxy) LookupJobStatusUpdates(w http.ResponseWriter, r *http.Request
 	fmt.Fprintln(w, string(js))
 }
 
+// URLIsReady returns true if hitting the URL returns a 200 series status code
+// and the Ingress exists inside the k8s cluster.
+func (c *CASProxy) URLIsReady(w http.ResponseWriter, r *http.Request) {
+	u := r.FormValue("url")
+
+	matches, err := c.URLMatches(u)
+	if err != nil {
+		http.Error(w, fmt.Sprintf("error checking URL %s: %s", u, err.Error()), http.StatusInternalServerError)
+		return
+	}
+	if !matches {
+		http.Error(w, fmt.Sprintf("URL %s is not a subdomain of %s", u, c.viceDomain), http.StatusBadRequest)
+		return
+	}
+
+	subdomain, err := extractSubdomain(u)
+	if err != nil {
+		http.Error(w, fmt.Sprintf("error getting subdomain for URL %s", u), http.StatusInternalServerError)
+		return
+	}
+	if subdomain == "" {
+		http.Error(w, fmt.Sprintf("empty subdomain for URL '%s'", u), http.StatusBadRequest)
+		return
+	}
+
+	var ready bool
+	ready, err = c.IngressExists(subdomain)
+	if err != nil {
+		http.Error(w, fmt.Sprintf("error checking ingress %s existence: %s", subdomain, err.Error()), http.StatusInternalServerError)
+		return
+	}
+
+	resp, err := http.Get(u)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	if resp.StatusCode < 200 || resp.StatusCode > 299 {
+		ready = ready && false
+	} else {
+		ready = ready && true
+	}
+
+	responseData := map[string]bool{
+		"ready": ready,
+	}
+	js, err := json.Marshal(responseData)
+	if err != nil {
+		http.Error(w, fmt.Sprintf("error marshalling json: %s", err.Error()), http.StatusInternalServerError)
+		return
+	}
+	fmt.Fprintln(w, string(js))
+}
+
 // RedirectToCAS redirects the request to CAS, setting the service query
 // parameter to the value in frontendURL.
 func (c *CASProxy) RedirectToCAS(w http.ResponseWriter, r *http.Request) {
@@ -520,6 +615,7 @@ func main() {
 		sslKey             = flag.String("ssl-key", "", "Path to the SSL .key file.")
 		ingressURL         = flag.String("ingress-url", "", "The URL to the cluster ingress.")
 		analysisHeader     = flag.String("analysis-header", "get-analysis-id", "The Host header for the ingress service that gets the analysis ID.")
+		appExposerHeader   = flag.String("app-exposer-header", "app-exposer", "The Host header value for the app-exposer service.")
 		accessHeader       = flag.String("access-header", "check-resource-access", "The Host header for the ingress service that checks analysis access.")
 		viceDomain         = flag.String("vice-domain", "cyverse.run", "The domain for the VICE apps.")
 		disableAutoRefresh = flag.Bool("disable-auto-refresh", false, "Turns off the auto-refresh feature on the loading page, which avoids hitting the graphql server.")
@@ -573,20 +669,23 @@ func main() {
 	}
 
 	p := &CASProxy{
-		casBase:        *casBase,
-		casValidate:    *casValidate,
-		frontendURL:    *frontendURL,
-		ingressURL:     *ingressURL,
-		accessHeader:   *accessHeader,
-		analysisHeader: *analysisHeader,
-		sessionStore:   sessionStore,
-		viceDomain:     *viceDomain,
-		refreshEnabled: !*disableAutoRefresh,
-		graphqlBase:    *graphqlBase,
+		casBase:          *casBase,
+		casValidate:      *casValidate,
+		frontendURL:      *frontendURL,
+		ingressURL:       *ingressURL,
+		appExposerHeader: *appExposerHeader,
+		accessHeader:     *accessHeader,
+		analysisHeader:   *analysisHeader,
+		sessionStore:     sessionStore,
+		viceDomain:       *viceDomain,
+		refreshEnabled:   !*disableAutoRefresh,
+		graphqlBase:      *graphqlBase,
 	}
 
 	r := mux.NewRouter()
 	api := r.PathPrefix("/api/").Subrouter()
+	api.Path("/url-ready").Queries("url", "").HandlerFunc(p.URLIsReady)
+
 	jobs := api.PathPrefix("/jobs/").Subrouter()
 	jobs.Path("/status-updates").Queries("url", "").HandlerFunc(p.LookupJobStatusUpdates)
 

--- a/main.go
+++ b/main.go
@@ -419,7 +419,7 @@ func (c *CASProxy) EndpointConfig(subdomain string) (*Endpoint, error) {
 
 	b, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
-		err = errors.Wrap(err, "error reading body of CAS response")
+		err = errors.Wrap(err, "error reading body of endpoint response")
 		return nil, err
 	}
 

--- a/main.go
+++ b/main.go
@@ -539,8 +539,8 @@ func (c *CASProxy) LookupJobStatusUpdates(w http.ResponseWriter, r *http.Request
 	fmt.Fprintln(w, string(js))
 }
 
-// URLIsReady returns true if hitting the URL returns a 200 series status code
-// and the Ingress exists inside the k8s cluster.
+// URLIsReady returns true if the Ingress for the provided URL exists and if a
+// connection attempt to the Endpoint for the Ingress succeeds.
 func (c *CASProxy) URLIsReady(w http.ResponseWriter, r *http.Request) {
 	u := r.FormValue("url")
 


### PR DESCRIPTION
Adds a /api/url-ready endpoint that should allow the loading page UI to know when the URL for the VICE app is actually accessible.